### PR TITLE
[Hotfix] 修正正則表達式以包含附件的 'a' 字元

### DIFF
--- a/Aws_util.php
+++ b/Aws_util.php
@@ -649,7 +649,7 @@ class Aws_util
             return;
         }
 
-        if (preg_match('|^[et]/|', $params['path'])) {
+        if (preg_match('|^[eta]/|', $params['path'])) {
             $segments = [
                 sprintf(
                     '%sepub.readmoo.%s',
@@ -681,7 +681,7 @@ class Aws_util
                 json_decode($file['setting'], true) :
                 $file['setting'];
 
-            if (preg_match('|^[et]/|', $setting['path'])) {
+            if (preg_match('|^[eta]/|', $setting['path'])) {
                 $segments = [
                     sprintf(
                         '%sepub.readmoo.%s',


### PR DESCRIPTION
## 變更說明
- 修改電子書路徑匹配模式，從 `[et]` 擴充為 `[eta]`
- 影響範圍：
  - `_s3_key_epub_prefix` 方法中的路徑匹配
  - `_s3_key_ebook` 方法中的路徑匹配

## 變更原因
- 為支援更多電子書路徑格式，將匹配模式從 `[et]` 擴充為 `[eta]`
- 此變更可確保系統能正確處理附件的路徑

## 相關文件
- 無

## 其他備註
- 此變更為向後相容，不會影響現有功能